### PR TITLE
add support for disabling the pay button

### DIFF
--- a/app/src/main/java/com/example/composepaybutton/MainActivity.kt
+++ b/app/src/main/java/com/example/composepaybutton/MainActivity.kt
@@ -81,9 +81,14 @@ class MainActivity : ComponentActivity() {
                     )
 
                     // Customized labels
+                    PayButton(onClick = onClick, allowedPaymentMethods = allowedPaymentMethods, type = ButtonType.Pay)
                     PayButton(onClick = onClick, allowedPaymentMethods = allowedPaymentMethods, type = ButtonType.Book)
                     PayButton(onClick = onClick, allowedPaymentMethods = allowedPaymentMethods, type = ButtonType.Subscribe)
                     PayButton(onClick = onClick, allowedPaymentMethods = allowedPaymentMethods, type = ButtonType.Donate)
+
+                    // Disabled buttons
+                    PayButton(onClick = onClick, allowedPaymentMethods = allowedPaymentMethods, type = ButtonType.Checkout, enabled = false)
+                    PayButton(onClick = onClick, allowedPaymentMethods = allowedPaymentMethods, type = ButtonType.Checkout, theme = ButtonTheme.Light, enabled = false)
                 }
             }
         }

--- a/compose-pay-button/src/main/java/com/google/pay/button/PayButton.kt
+++ b/compose-pay-button/src/main/java/com/google/pay/button/PayButton.kt
@@ -43,6 +43,9 @@ enum class ButtonType(val value: Int) {
     Subscribe(ButtonConstants.ButtonType.SUBSCRIBE),
 }
 
+private const val FULL_ALPHA = 1f
+private const val HALF_ALPHA = 0.5f
+
 @Composable
 fun PayButton(
     onClick: () -> Unit,
@@ -51,6 +54,7 @@ fun PayButton(
     theme: ButtonTheme = ButtonTheme.Dark,
     type: ButtonType = ButtonType.Buy,
     radius: Dp = 100.dp,
+    enabled: Boolean = true,
 ) {
 
     val radiusPixelValue = with(LocalDensity.current) { radius.toPx().toInt() }
@@ -59,13 +63,26 @@ fun PayButton(
         modifier = modifier,
         factory = { context ->
             GmsPayButton(context).apply {
-                this.initialize(ButtonOptions.newBuilder()
-                    .setButtonTheme(theme.value)
-                    .setButtonType(type.value)
-                    .setCornerRadius(radiusPixelValue)
-                    .setAllowedPaymentMethods(allowedPaymentMethods)
-                    .build())
-                setOnClickListener { onClick() }
+                this.initialize(
+                    ButtonOptions.newBuilder()
+                        .setButtonTheme(theme.value)
+                        .setButtonType(type.value)
+                        .setCornerRadius(radiusPixelValue)
+                        .setAllowedPaymentMethods(allowedPaymentMethods)
+                        .build()
+                )
+            }
+        },
+        update = { button ->
+            button.apply {
+                alpha = if (enabled) FULL_ALPHA else HALF_ALPHA
+                isEnabled = enabled
+
+                if (enabled) {
+                    setOnClickListener { onClick() }
+                } else {
+                    setOnClickListener(null)
+                }
             }
         }
     )


### PR DESCRIPTION
Adds a new `enabled` property on the button:
```
PayButton(
  onClick = onClick,
  allowedPaymentMethods = allowedPaymentMethods,
  enabled = false
)
```
If `enabled` is set to `false` the buttons click listener gets removed and the button is greyed out:

<img width="577" alt="image" src="https://github.com/google-pay/compose-pay-button/assets/4389374/e3ac198b-1e60-46dc-9a5c-221a26f46cfe">
