### PR TITLE
Add Gradle version catalog

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
- plugins {
-    id 'com.android.application'
-    id 'org.jetbrains.kotlin.android'
+plugins {
+    alias(libs.plugins.androidApplication)
+    alias(libs.plugins.kotlinAndroid)
 }
 
 android {
@@ -65,10 +65,8 @@ android {
 dependencies {
     implementation project(':compose-pay-button')
 
-    implementation 'androidx.core:core-ktx:1.12.0'
-    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.6.2'
-    implementation 'androidx.activity:activity-compose:1.8.1'
-    implementation "androidx.compose.ui:ui:$compose_ui_version"
-    implementation "androidx.compose.ui:ui-tooling-preview:$compose_ui_version"
-    implementation 'androidx.compose.material:material:1.5.4'
+    implementation libs.compose.ui
+    implementation libs.compose.material
+    implementation libs.sample.compose.activity
+    implementation libs.sample.compose.ui.tooling
 }

--- a/app/src/main/java/com/example/composepaybutton/MainActivity.kt
+++ b/app/src/main/java/com/example/composepaybutton/MainActivity.kt
@@ -23,16 +23,12 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.Divider
-import androidx.compose.material.LocalTextStyle
 import androidx.compose.material.Text
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.PlatformTextStyle
-import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
 
 import com.google.pay.button.ButtonTheme

--- a/build.gradle
+++ b/build.gradle
@@ -14,17 +14,8 @@
  * limitations under the License.
  */
 
-buildscript {
-    ext {
-        compose_ui_version = '1.5.4'
-    }
-}
-
-plugins {
-    id 'io.github.gradle-nexus.publish-plugin' version '1.3.0'
-    id 'com.android.application' version '8.2.2' apply false
-    id 'com.android.library' version '8.2.2' apply false
-    id 'org.jetbrains.kotlin.android' version '1.8.20' apply false
+plugins {  
+    alias(libs.plugins.nexusPublishingPlugin)
 }
 
 apply from: "${rootDir}/scripts/publish-root.gradle"

--- a/compose-pay-button/build.gradle
+++ b/compose-pay-button/build.gradle
@@ -15,8 +15,8 @@
  */
 
 plugins {
-    id 'com.android.library'
-    id 'org.jetbrains.kotlin.android'
+    alias(libs.plugins.androidLibrary)
+    alias(libs.plugins.kotlinAndroid)
 }
 
 ext {
@@ -69,8 +69,8 @@ android {
 }
 
 dependencies {
-    implementation 'com.google.android.gms:play-services-wallet:19.3.0'
-    implementation "androidx.compose.ui:ui:$compose_ui_version"
-    implementation 'androidx.compose.material:material:1.6.2'
-    implementation 'androidx.core:core-ktx:1.12.0'
+    implementation libs.playServices.wallet
+    implementation libs.compose.ui
+    implementation libs.compose.material
+    implementation libs.androidx.core
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,16 @@
+[libraries]
+# Library
+compose-ui = "androidx.compose.ui:ui:1.5.3"
+compose-material = "androidx.compose.material:material:1.6.2"
+androidx-core = "androidx.core:core-ktx:1.12.0"
+playServices-wallet = "com.google.android.gms:play-services-wallet:19.3.0"
+
+# Sample/App
+sample-compose-ui-tooling = "androidx.compose.ui:ui-tooling-preview:1.5.3"
+sample-compose-activity = "androidx.activity:activity-compose:1.8.1"
+
+[plugins]
+nexusPublishingPlugin = "io.github.gradle-nexus.publish-plugin:1.3.0"
+androidApplication = "com.android.application:8.2.2"
+androidLibrary = "com.android.library:8.2.2"
+kotlinAndroid = "org.jetbrains.kotlin.android:1.8.20"


### PR DESCRIPTION
I just added the "new" Gradle version catalog for easier dependency managament.
Also it is helpful if we want to add Dependabot to the project 🙃 

While doing that, I realized that:
* The sample declared two dependency that are not needed (lifecycle-runtime & androidx.core), so i removed it
* The `MainActivity` had some unused imports, so I removed it
* The `compose-material` dependency differs in sample (1.5.4) and library (1.6.2), so I aligned it and used 1.6.2 in the sample too


