### PR TITLE
[#109] Handle potential init exceptions and fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,3 +86,12 @@ class MainActivity : ComponentActivity() {
     }
 }
 ```
+
+## Error handling and Fallback UI
+
+The `PayButton` composable wraps the underlying `PayButton` Android View, which may encounter errors during initialization. To handle these situations, the `PayButton` composable provides:
+
+*   **`onError` Callback:** Invoked when an error occurs during the button's initialization. This callback receives the `Throwable` that caused the error, allowing you to log it or take other actions.
+*   **`fallbackUi` Composable:** An optional composable function that is displayed in place of the button if an error occurs. If not provided, nothing will be displayed in case of error.
+
+This mechanism ensures that your app can gracefully handle potential issues with the `PayButton` and provide a fallback experience to the user.

--- a/app/src/main/java/com/example/composepaybutton/MainActivity.kt
+++ b/app/src/main/java/com/example/composepaybutton/MainActivity.kt
@@ -24,6 +24,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.width
+import androidx.compose.material.Button
 import androidx.compose.material.Divider
 import androidx.compose.material.Text
 import androidx.compose.ui.Alignment
@@ -103,6 +104,12 @@ class MainActivity : ComponentActivity() {
                     // Disabled buttons
                     PayButton(onClick = onClick, allowedPaymentMethods = allowedPaymentMethods, type = ButtonType.Checkout, enabled = false)
                     PayButton(onClick = onClick, allowedPaymentMethods = allowedPaymentMethods, type = ButtonType.Checkout, theme = ButtonTheme.Light, enabled = false)
+
+                    Divider(thickness = 1.dp, color = Color.LightGray)
+                    Text("Fallback UI")
+
+                    // Fallback UI in case of init failure
+                    PayButton(onClick = onClick, allowedPaymentMethods = allowedPaymentMethods, onError = { println("Error: $it") }) { Button(onClick = onClick) { Text("Fallback UI") }}
                 }
             }
         }


### PR DESCRIPTION
As discussed in this issue #109, this library serves as a Compose UI wrapper for the "PayButton" View, initializing within the Compose function.
It may crash for various reasons; thus, this PR introduces an `onError` callback and a `fallbackUi` to prevent the client app's payment flow from breaking.